### PR TITLE
Update the way we ask for the build list

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/benmatselby/go-vsts"
   packages = ["vsts"]
-  revision = "12dc4aced373cac3348c7398cc689d5abd467efe"
+  revision = "0591d984559ef6caad67634f43abf8bdd7858610"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -41,7 +41,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "78d5f264b493f125018180c204871ecf58a2dce1"
+  revision = "d0faeb539838e250bd0a9db4182d48d4a1915181"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/build.go
+++ b/build.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/benmatselby/go-vsts/vsts"
 	"github.com/urfave/cli"
 )
 
@@ -15,7 +16,8 @@ func ListBuilds(c *cli.Context) {
 	count := c.Int("count")
 	filterBranch := c.String("branch")
 
-	builds, error := client.Builds.List()
+	options := &vsts.BuildsListOptions{}
+	builds, error := client.Builds.List(options)
 	if error != nil {
 		fmt.Println(error)
 	}


### PR DESCRIPTION
This is required due to the change in the underlying package that now allows the developer to pass in an options struct to determine what builds to fetch back