### PR TITLE
Add a boolean flag to show tags for delivery plans

### DIFF
--- a/delivery_plan.go
+++ b/delivery_plan.go
@@ -42,6 +42,7 @@ func ListDeliveryPlans(c *cli.Context) {
 // GetDeliveryPlanTimeLine will call the VSTS API and get a list of delivery plans
 func GetDeliveryPlanTimeLine(c *cli.Context) {
 	planName := c.Args()[0]
+	showTag := c.Bool("show-tag")
 
 	options := &vsts.DeliveryPlansListOptions{}
 	plans, _, err := client.DeliveryPlans.List(options)
@@ -87,11 +88,17 @@ func GetDeliveryPlanTimeLine(c *cli.Context) {
 					fmt.Println()
 
 					for _, item := range iteration.WorkItems {
-						fmt.Printf(
-							"* %v - %s\n",
+						line := fmt.Sprintf(
+							"* %v - %s",
 							item[vsts.DeliveryPlanWorkItemIDKey],
 							item[vsts.DeliveryPlanWorkItemNameKey],
 						)
+
+						if showTag {
+							line += fmt.Sprintf(" (%s)", item[vsts.DeliveryPlanWorkItemTagKey])
+						}
+
+						fmt.Println(line)
 					}
 
 					fmt.Println()

--- a/main.go
+++ b/main.go
@@ -130,9 +130,12 @@ func main() {
 			Category: "plans",
 		},
 		{
-			Name:     "plan:timeline",
-			Usage:    "     Show the delivery plan timeline",
-			Action:   GetDeliveryPlanTimeLine,
+			Name:   "plan:timeline",
+			Usage:  "     Show the delivery plan timeline",
+			Action: GetDeliveryPlanTimeLine,
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "show-tag", Usage: "Should we show any tags for the items in the plan"},
+			},
 			Category: "plans",
 		},
 		{


### PR DESCRIPTION
Tags are used for various reasons, and being able to display tag based information may well be useful (It's useful in my current place of work for example). So by default, don't show the tags, but if you add `--show-tag` to the `plan:timeline` command then show the tags aligned to each item in the plan