### PR TITLE
Provide a overview of builds based on path for build definitions

### DIFF
--- a/build.go
+++ b/build.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -30,6 +32,44 @@ func ListBuilds(c *cli.Context) {
 		count = len(builds)
 	}
 
+	renderBuilds(builds, count, filterBranch)
+}
+
+// ListBuildOverview will call the VSTS API and get a list of builds for a given path
+func ListBuildOverview(c *cli.Context) {
+	filterBranch := c.String("branch")
+	path := c.String("path")
+
+	buildDefOpts := vsts.BuildDefinitionsListOptions{Path: "\\" + path}
+	definitions, err := client.BuildDefinitions.List(&buildDefOpts)
+	if err != nil {
+		fmt.Printf("unable to get a list of build definitions: %v", err)
+		return
+	}
+
+	var builds []vsts.Build
+	for _, definition := range definitions {
+		for _, branchName := range strings.Split(filterBranch, ",") {
+			build, err := getVstsBuildsForBranch(definition.ID, branchName)
+			if err != nil {
+				fmt.Printf("unable to get builds for definition %s: %v", definition.Name, err)
+			}
+			if len(build) > 0 {
+				builds = append(builds, build[0])
+			}
+		}
+	}
+
+	renderBuilds(builds, len(builds), ".*")
+}
+
+func getVstsBuildsForBranch(defID int, branchName string) ([]vsts.Build, error) {
+	buildOpts := vsts.BuildsListOptions{Definitions: strconv.Itoa(defID), Branch: "refs/heads/" + branchName, Count: 1}
+	build, err := client.Builds.List(&buildOpts)
+	return build, err
+}
+
+func renderBuilds(builds []vsts.Build, count int, filterBranch string) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.FilterHTML)
 	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", "", "Name", "Branch", "Build", "Finished")
 	for index := 0; index < count; index++ {

--- a/main.go
+++ b/main.go
@@ -83,11 +83,21 @@ func main() {
 	app.Commands = []cli.Command{
 		{
 			Name:   "build:list",
-			Usage:  "        List all the builds",
+			Usage:  "    List all the builds",
 			Action: ListBuilds,
 			Flags: []cli.Flag{
 				cli.IntFlag{Name: "count", Value: 10, Usage: "How many builds to display"},
 				cli.StringFlag{Name: "branch", Value: ".*", Usage: "Filter by branch name"},
+			},
+			Category: "build",
+		},
+		{
+			Name:   "build:overview",
+			Usage:  "    Show build overview for build definitions in a given path",
+			Action: ListBuildOverview,
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "path", Value: os.Getenv("VSTS_TEAM"), Usage: "Build definition path"},
+				cli.StringFlag{Name: "branch", Value: "master", Usage: "Filter by branch name"},
 			},
 			Category: "build",
 		},


### PR DESCRIPTION
Provide a CLI overview of what you get in the build definitions overview screen. This allows the user to provide a folder path to determine which builds we want to see. It takes the last build for a given branch and folder and then renders the output