### PR TITLE
Make the build:list faster

### DIFF
--- a/build.go
+++ b/build.go
@@ -18,7 +18,9 @@ func ListBuilds(c *cli.Context) {
 	count := c.Int("count")
 	filterBranch := c.String("branch")
 
-	options := &vsts.BuildsListOptions{}
+	options := &vsts.BuildsListOptions{
+		Count: count,
+	}
 	builds, err := client.Builds.List(options)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to get a list of builds: %v", err)
@@ -29,11 +31,7 @@ func ListBuilds(c *cli.Context) {
 		return
 	}
 
-	if len(builds) < count {
-		count = len(builds)
-	}
-
-	renderBuilds(builds, count, filterBranch)
+	renderBuilds(builds, len(builds), filterBranch)
 }
 
 // ListBuildOverview will call the VSTS API and get a list of builds for a given path


### PR DESCRIPTION
I noticed that it was slowing down and this was because there was no
count being requested, so it was returning over 500 records, and then
chopping the data set down to x (x being 10 in most cases)

This now asks the API for the amount of builds we want to see, much
faster!!