### PR TITLE
Provide a way to list teams for the org

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:32a4531383fc6b1e897ec5f1afecbcf089a71a5bce9c45c660e31e33e20dc8eb"
+  digest = "1:689c510b690a82cf6978fe929aee389282c1bec771e8bb871629da146fba45e1"
   name = "github.com/benmatselby/go-azuredevops"
   packages = ["azuredevops"]
   pruneopts = "UT"
-  revision = "7381aa93bebc601ae80b59ecb1881e1542bf2022"
+  revision = "8d2e71ef2a7e2091e1e4b5546ac6d24bccc7aa63"
 
 [[projects]]
   branch = "master"
@@ -15,7 +15,7 @@
   name = "github.com/google/go-querystring"
   packages = ["query"]
   pruneopts = "UT"
-  revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
 
 [[projects]]
   digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"

--- a/main.go
+++ b/main.go
@@ -178,10 +178,13 @@ func main() {
 			Category: "pull requests",
 		},
 		{
-			Name:     "t:list",
-			Usage:    "List all the teams",
-			Action:   ListTeams,
-			Aliases:  []string{"tl"},
+			Name:    "t:list",
+			Usage:   "List all the teams",
+			Action:  ListTeams,
+			Aliases: []string{"tl"},
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "mine", Usage: "Show my teams only"},
+			},
 			Category: "teams",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -177,6 +177,13 @@ func main() {
 			},
 			Category: "pull requests",
 		},
+		{
+			Name:     "t:list",
+			Usage:    "List all the teams",
+			Action:   ListTeams,
+			Aliases:  []string{"tl"},
+			Category: "teams",
+		},
 	}
 
 	app.Run(os.Args)

--- a/team.go
+++ b/team.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/benmatselby/go-azuredevops/azuredevops"
+	"github.com/urfave/cli"
+)
+
+// ListTeams will return all the teams for the organisation
+func ListTeams(c *cli.Context) {
+	opts := azuredevops.TeamsListOptions{}
+	teams, _, err := client.Teams.List(&opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get teams: %+v", err)
+		os.Exit(2)
+	}
+
+	sort.Slice(teams, func(i, j int) bool {
+		return teams[i].Name < teams[j].Name
+	})
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.FilterHTML)
+
+	for _, team := range teams {
+		fmt.Fprintf(w, "%s\n", team.Name)
+	}
+
+	w.Flush()
+}

--- a/team.go
+++ b/team.go
@@ -12,7 +12,11 @@ import (
 
 // ListTeams will return all the teams for the organisation
 func ListTeams(c *cli.Context) {
-	opts := azuredevops.TeamsListOptions{}
+	filterMine := c.Bool("mine")
+
+	opts := azuredevops.TeamsListOptions{
+		Mine: filterMine,
+	}
 	teams, _, err := client.Teams.List(&opts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to get teams: %+v", err)


### PR DESCRIPTION
Resolves #21 

The `addition-of-teams-api-calls` needs merging in benmatselby/go-azuredevops first though